### PR TITLE
Fix dev deployment failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-shiny==1.4.0
+shiny==1.5.1
 pandas==3.0.1
 numpy==2.4.2
 matplotlib==3.10.8


### PR DESCRIPTION
I changed the shiny version to be compatible with querychat by pip installation dependency requirements. 